### PR TITLE
feat: add standard attributes to spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,6 +974,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1468,6 +1480,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "regex",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ opentelemetry = { version = "0.30.0"}
 opentelemetry_sdk = { version = "0.30.0" }
 opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic"] }
 opentelemetry-semantic-conventions = { version = "0.30.0", features = ["semconv_experimental"] }
+regex = "1.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 tokio = { version = "1", features = ["full"] }

--- a/docs/design/semconv.md
+++ b/docs/design/semconv.md
@@ -10,10 +10,12 @@ response handling.
 
 The following attributes are added 
 
-| Attribute      | Type   | Description                               | Examples           |
-|----------------|--------|-------------------------------------------|--------------------|
-| `varnish.vxid` | String | ID of the transaction.                    | `213`              |
-| `varnish.side` | String | Request handling side.                    | `client`;`backend` |
-| `varnish.vcl`  | String | Name of the VCL that handles the request. | `boot`             |
+| Attribute                     | Type    | Description                                   | Examples           |
+|-------------------------------|---------|-----------------------------------------------|--------------------|
+| `varnish.vxid`                | String  | ID of the transaction.                        | `213`              |
+| `varnish.side`                | String  | Request handling side.                        | `client`;`backend` |
+| `varnish.vcl`                 | String  | Name of the VCL that handles the request.     | `boot`             |
+| `varnish.backend.name`        | String  | Name of the backend that handles the request. | `default`          |
+| `varnish.backend.conn_reused` | Boolean | Indicates if the connection has been reused.  | `false`            |
 
 The Rust package `varnishotel_semconv` is added to hold those attributes. 

--- a/src/varnishlogreceiver/mod.rs
+++ b/src/varnishlogreceiver/mod.rs
@@ -119,6 +119,14 @@ impl VarnishTx {
             self.id.clone(),
         ));
 
+        for event in self.timeline.clone() {
+            let event_name = event.name;
+            let event_ts =
+                std::time::UNIX_EPOCH + std::time::Duration::from_secs_f64(event.timestamp);
+
+            span.add_event_with_timestamp(event_name, event_ts, vec![]);
+        }
+    
         span
     }
 }

--- a/src/varnishlogreceiver/mod.rs
+++ b/src/varnishlogreceiver/mod.rs
@@ -126,6 +126,15 @@ impl VarnishTx {
                 b.r_addr.clone(),
             ));
             span.set_attribute(KeyValue::new(semconv::trace::NETWORK_PEER_PORT, b.r_port));
+
+            span.set_attribute(KeyValue::new(
+                varnishotel_semconv::VARNISH_BACKEND_NAME,
+                b.name.clone(),
+            ));
+            span.set_attribute(KeyValue::new(
+                varnishotel_semconv::VARNISH_BACKEND_CONN_REUSED,
+                b.conn_reused.unwrap_or_default(),
+            ));
         }
 
         if let Some(c) = &self.client {

--- a/varnishotel_semconv/src/lib.rs
+++ b/varnishotel_semconv/src/lib.rs
@@ -6,3 +6,10 @@ pub const VARNISH_VCL: &str = "varnish.vcl";
 
 /// The Varnish request side (`client` or `backend`).
 pub const VARNISH_SIDE: &str = "varnish.side";
+
+/// The Varnish backend name.
+pub const VARNISH_BACKEND_NAME: &str = "varnish.backend.name";
+
+/// Indicates if the backend connection was reused by Varnish from
+/// an existing pool of connections.
+pub const VARNISH_BACKEND_CONN_REUSED: &str = "varnish.backend.conn_reused";


### PR DESCRIPTION
Fixes #6.

## Changes

This change adds a set of new attributes to `VarnishTx` spans. Most notably:

- Standard HTTP attributes
- New Varnish attributes `backend.name` and `backend.conn_reused`

Also, a new generic method is added to make the extraction reusable across
root/sub spans.

## Merge requirement checklist

* [x] Documentation is updated (if applicable)
* [x] Unit tests added/updated (if applicable)
* [x] Changes in public API reviewed (if applicable)
